### PR TITLE
Update E2E docker-compose download script for private flux repo

### DIFF
--- a/development.sh
+++ b/development.sh
@@ -7,22 +7,26 @@ WD=$(dirname "$0")
 cd "${WD}"
 
 # initialize package folder
-mkdir -p ./docker
+mkdir -p ./docker/update
 
 DOCKER_COMPOSE_CMD="docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.custom.yml"
 
 function check_docker {
-  # compare versions
-  GITHUB_VERSION=$(curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/e2e-docker-compose/RELEASE_VERSION.txt --silent)
-  LOCAL_VERSION=$(cat ./docker/RELEASE_VERSION.txt || echo "unknown")
+  # based on https://github.com/HSLdevcom/jore4-flux#docker-compose
 
-  # download latest version of the docker-compose package in case it has changed
-  if [ "$GITHUB_VERSION" != "$LOCAL_VERSION" ]; then
-    echo "E2E docker-compose package is not up to date, downloading a new version."
-    curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/e2e-docker-compose/e2e-docker-compose.tar.gz --silent | tar -xzf - -C ./docker/
-  else
-    echo "E2E docker-compose package is up to date, no need to download new version."
+  if ! command -v gh; then
+    echo "Please install the github gh tool on your machine."
+    exit 1
   fi
+
+  echo "Downloading latest version of E2E docker-compose package..."
+  gh auth status || gh auth login
+
+  # gh cannot overwrite existing files, therefore first download into separate dir. This way we still have the old copy
+  # in case the download fails
+  rm -rf ./docker/update/*
+  gh release download e2e-docker-compose --repo HSLdevcom/jore4-flux --dir ./docker/update
+  cp -R ./docker/update/* ./docker
 }
 
 function start {


### PR DESCRIPTION
The github gh-tool is used to download flux-releases instead of a direct https-download.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hastus/3)
<!-- Reviewable:end -->
