### PR TITLE
Upgrade `ktlint-maven-plugin`: `1.5.2` -> `1.16.0`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+ij_kotlin_allow_trailing_comma_on_call_site=false
+ij_kotlin_allow_trailing_comma=false

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <build-properties-plugin.version>1.1.0</build-properties-plugin.version>
         <kotlin-plugin.version>1.7.20</kotlin-plugin.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
-        <ktlint-plugin.version>1.15.2</ktlint-plugin.version>
+        <ktlint-plugin.version>1.16.0</ktlint-plugin.version>
 
         <!-- Library versions -->
         <kotlin-logging-jvm.version>3.0.2</kotlin-logging-jvm.version>


### PR DESCRIPTION
Also, use "do not allow trailing commas" rule because by default ktlint enforces them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/18)
<!-- Reviewable:end -->
