### PR TITLE
Make saving timetables synchronous

### DIFF
--- a/src/main/kotlin/fi/hsl/jore4/hastus/graphql/GraphQLService.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/graphql/GraphQLService.kt
@@ -256,6 +256,10 @@ class GraphQLService(
             .orEmpty()
     }
 
+    /* Use synchronized when persisting data to graphQL, since there is no transaction support for it.
+    *  Multiple simultaneous modifications of the same table will fail.
+    */
+    @Synchronized
     fun persistVehicleScheduleFrame(
         journeyPatterns: Collection<JoreJourneyPattern>,
         vehicleScheduleFrame: JoreVehicleScheduleFrame,


### PR DESCRIPTION
Move importing timetables to its own synchronous function, as using transactions is not fully supported via Hasura GraphQL

Resolves https://github.com/HSLdevcom/jore4/issues/1352

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/25)
<!-- Reviewable:end -->
