### PR TITLE
Fix parsing timestamps from GraphQL responses

### DIFF
--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -32,4 +32,4 @@ jobs:
         uses: HSLdevcom/jore4-tools/github-actions/seed-infrastructure-links@seed-infrastructure-links-v1
 
       - name: Run e2e tests from github action
-        uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v2
+        uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v1

--- a/src/main/kotlin/fi/hsl/jore4/hastus/graphql/converter/DateTimeScalarConverter.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/graphql/converter/DateTimeScalarConverter.kt
@@ -3,22 +3,38 @@ package fi.hsl.jore4.hastus.graphql.converter
 import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
 
 class DateTimeScalarConverter : ScalarConverter<OffsetDateTime> {
-    override fun toJson(value: OffsetDateTime): String {
-        return value.format(formatter)
-    }
+
+    override fun toJson(value: OffsetDateTime): String = value.format(dateTimeFormatterForSerialising)
 
     override fun toScalar(rawValue: Any): OffsetDateTime {
-        if (rawValue is String) {
-            return OffsetDateTime.parse(rawValue, formatter)
+        return when (rawValue) {
+            is String -> OffsetDateTime.parse(rawValue, dateTimeFormatterForDeserialising)
+
+            else -> throw IllegalArgumentException("Error parsing $rawValue as OffsetDateTime")
         }
-        throw IllegalArgumentException("Error parsing $rawValue as date, expected format $dateFormat")
     }
 
     companion object {
-        const val dateFormat = "yyyy-MM-dd HH:mm:ss.SSS Z"
 
-        val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(dateFormat)
+        private const val DATETIME_FORMAT_MILLISECONDS = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+
+        private val dateTimeFormatterForSerialising = DateTimeFormatter.ofPattern(DATETIME_FORMAT_MILLISECONDS)
+
+        /**
+         * It turns out that GraphQL responses have a variable number of decimals in the
+         * timestamps in terms of fractions of seconds. This happens because the trailing
+         * zeros are removed from the decimal part. Therefore, we construct the formatter for
+         * deserialising in such a way that variable number of digits in the decimal part is
+         * supported.
+         */
+        private val dateTimeFormatterForDeserialising: DateTimeFormatter = DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 3, true)
+            .appendOffset("+HH:MM", "Z")
+            .toFormatter()
     }
 }

--- a/src/test/kotlin/fi/hsl/jore4/hastus/test/ObjectMapperTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/test/ObjectMapperTest.kt
@@ -48,33 +48,39 @@ class ObjectMapperTest {
         @JsonDeserialize(converter = AnyToUUIDConverter::class)
         val uuid: UUID
     )
+
     data class UUIDListFormat(
         @JsonSerialize(converter = UUIDListToAnyConverter::class)
         @JsonDeserialize(converter = AnyToUUIDListConverter::class)
         val uuidList: UUIDList
     )
+
     data class DateFormat(
         @JsonSerialize(converter = LocalDateToAnyConverter::class)
         @JsonDeserialize(converter = AnyToLocalDateConverter::class)
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         val date: LocalDate
     )
-    data class OffsetTimeFormat(
+
+    data class OffsetDateTimeFormat(
         @JsonSerialize(converter = OffsetDateTimeToAnyConverter::class)
         @JsonDeserialize(converter = AnyToOffsetDateTimeConverter::class)
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSS Z")
-        val offsetTime: OffsetDateTime
+        val offsetDateTime: OffsetDateTime
     )
-    data class IjsonbFormat(
+
+    data class IJsonbFormat(
         @JsonSerialize(converter = IJSONBToAnyConverter::class)
         @JsonDeserialize(converter = AnyToIJSONBConverter::class)
         val ijsonb: IJSONB
     )
+
     data class CoordinateFormat(
         @JsonSerialize(converter = CoordinateToAnyConverter::class)
         @JsonDeserialize(converter = AnyToCoordinateConverter::class)
         val coordinate: Coordinate
     )
+
     data class DurationFormat(
         @JsonSerialize(converter = DurationToAnyConverter::class)
         @JsonDeserialize(converter = AnyToDurationConverter::class)
@@ -139,9 +145,9 @@ class ObjectMapperTest {
         fun `test offset time mapping`() {
             val value = OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 4000000, ZoneOffset.UTC)
             val expected = """
-            {"offsetTime":"2022-02-02 01:02:03.004 +0000"}
+            {"offsetDateTime":"2022-02-02 01:02:03.004 +0000"}
             """.trimIndent()
-            val formatted = objectMapper.writeValueAsString(OffsetTimeFormat(value))
+            val formatted = objectMapper.writeValueAsString(OffsetDateTimeFormat(value))
             assertEquals(expected, formatted)
         }
 
@@ -151,7 +157,7 @@ class ObjectMapperTest {
             val expected = """
             {"ijsonb":{"first":"value","second":"other"}}
             """.trimIndent()
-            val formatted = objectMapper.writeValueAsString(IjsonbFormat(value))
+            val formatted = objectMapper.writeValueAsString(IJsonbFormat(value))
             assertEquals(expected, formatted)
         }
 
@@ -221,11 +227,11 @@ class ObjectMapperTest {
             val value = OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 4000000, ZoneOffset.UTC)
             val jsonString = """
             {
-                "offsetTime": "2022-02-02 01:02:03.004 +0000"
+                "offsetDateTime": "2022-02-02 01:02:03.004 +0000"
             }
             """.trimIndent()
-            val parsed: OffsetTimeFormat = objectMapper.readValue(jsonString)
-            assertEquals(value, parsed.offsetTime)
+            val parsed: OffsetDateTimeFormat = objectMapper.readValue(jsonString)
+            assertEquals(value, parsed.offsetDateTime)
         }
 
         @Test
@@ -239,7 +245,7 @@ class ObjectMapperTest {
                 }
             }
             """.trimIndent()
-            val parsed: IjsonbFormat = objectMapper.readValue(jsonString)
+            val parsed: IJsonbFormat = objectMapper.readValue(jsonString)
             assertEquals(value, parsed.ijsonb.content)
         }
 

--- a/src/test/kotlin/fi/hsl/jore4/hastus/test/ObjectMapperTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/test/ObjectMapperTest.kt
@@ -65,7 +65,6 @@ class ObjectMapperTest {
     data class OffsetDateTimeFormat(
         @JsonSerialize(converter = OffsetDateTimeToAnyConverter::class)
         @JsonDeserialize(converter = AnyToOffsetDateTimeConverter::class)
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSS Z")
         val offsetDateTime: OffsetDateTime
     )
 
@@ -88,8 +87,8 @@ class ObjectMapperTest {
     )
 
     @Test
-    @DisplayName("When parsing JSON")
-    fun testJsonForm() {
+    @DisplayName("When parsing export parameters from JSON")
+    fun testParsingExportParametersFromJson() {
         val jsonString = """
         {
             "uniqueLabels": ["65x", "65y"],
@@ -141,14 +140,50 @@ class ObjectMapperTest {
             assertEquals(expected, formatted)
         }
 
-        @Test
-        fun `format OffsetDateTime as JSON`() {
-            val value = OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 4000000, ZoneOffset.UTC)
-            val expected = """
-            {"offsetDateTime":"2022-02-02 01:02:03.004 +0000"}
-            """.trimIndent()
-            val formatted = objectMapper.writeValueAsString(OffsetDateTimeFormat(value))
-            assertEquals(expected, formatted)
+        @Nested
+        @DisplayName("format OffsetDateTime as JSON")
+        inner class TestSerialisingOffsetDateTimeToJson {
+
+            private fun doAssert(expected: String, timestamp: OffsetDateTime) {
+                assertEquals(
+                    """
+                    {"offsetDateTime":"$expected"}
+                    """.trimIndent(),
+                    objectMapper.writeValueAsString(OffsetDateTimeFormat(timestamp))
+                )
+            }
+
+            @Test
+            fun `with UTC zone`() {
+                // zero milliseconds
+                doAssert(
+                    "2022-02-02T01:02:03.000Z",
+                    OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 0, ZoneOffset.UTC)
+                )
+
+                // non-zero milliseconds
+                doAssert(
+                    "2022-02-02T01:02:03.004Z",
+                    OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 4_000_000, ZoneOffset.UTC)
+                )
+            }
+
+            @Test
+            fun `with offset timezone`() {
+                val zoneOffset = ZoneOffset.of("+03:00")
+
+                // zero milliseconds
+                doAssert(
+                    "2022-02-02T01:02:03.000+03:00",
+                    OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 0, zoneOffset)
+                )
+
+                // non-zero milliseconds
+                doAssert(
+                    "2022-02-02T01:02:03.004+03:00",
+                    OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 4_000_000, zoneOffset)
+                )
+            }
         }
 
         @Test
@@ -222,16 +257,76 @@ class ObjectMapperTest {
             assertEquals(value, parsed.date)
         }
 
-        @Test
-        fun `parse OffsetDateTime from JSON`() {
-            val value = OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 4000000, ZoneOffset.UTC)
-            val jsonString = """
-            {
-                "offsetDateTime": "2022-02-02 01:02:03.004 +0000"
+        @Nested
+        @DisplayName("parse OffsetDateTime from JSON")
+        inner class TestDeserialisingOffsetDateTimeFromJSON {
+
+            private fun doAssert(expected: OffsetDateTime, timestamp: String) {
+                assertEquals(
+                    expected,
+                    objectMapper.readValue<OffsetDateTimeFormat>(
+                        """{"offsetDateTime": "$timestamp"}"""
+                    ).offsetDateTime
+                )
             }
-            """.trimIndent()
-            val parsed: OffsetDateTimeFormat = objectMapper.readValue(jsonString)
-            assertEquals(value, parsed.offsetDateTime)
+
+            @Nested
+            @DisplayName("with UTC timezone")
+            inner class WithUtcTimezone {
+
+                private fun createOffsetDateTime(nanoOfSecond: Int) = OffsetDateTime
+                    .of(2022, 2, 2, 1, 2, 3, nanoOfSecond, ZoneOffset.UTC)
+
+                @Test
+                fun `without fractions of seconds`() {
+                    doAssert(createOffsetDateTime(0), "2022-02-02T01:02:03Z")
+                }
+
+                @Test
+                fun `with deci-seconds`() {
+                    doAssert(createOffsetDateTime(400_000_000), "2022-02-02T01:02:03.4Z")
+                }
+
+                @Test
+                fun `with centi-seconds`() {
+                    doAssert(createOffsetDateTime(40_000_000), "2022-02-02T01:02:03.04Z")
+                }
+
+                @Test
+                fun `with milliseconds`() {
+                    doAssert(createOffsetDateTime(4_000_000), "2022-02-02T01:02:03.004Z")
+                }
+            }
+
+            @Nested
+            @DisplayName("with offset timezone")
+            inner class WithOffsetTimezone {
+
+                private val zoneOffset = ZoneOffset.of("+03:00")
+
+                private fun createOffsetDateTime(nanoOfSecond: Int) = OffsetDateTime
+                    .of(2022, 2, 2, 1, 2, 3, nanoOfSecond, zoneOffset)
+
+                @Test
+                fun `without fractions of seconds`() {
+                    doAssert(createOffsetDateTime(0), "2022-02-02T01:02:03+03:00")
+                }
+
+                @Test
+                fun `with deci-seconds`() {
+                    doAssert(createOffsetDateTime(400_000_000), "2022-02-02T01:02:03.4+03:00")
+                }
+
+                @Test
+                fun `with centi-seconds`() {
+                    doAssert(createOffsetDateTime(40_000_000), "2022-02-02T01:02:03.04+03:00")
+                }
+
+                @Test
+                fun `with milliseconds`() {
+                    doAssert(createOffsetDateTime(4_000_000), "2022-02-02T01:02:03.004+03:00")
+                }
+            }
         }
 
         @Test

--- a/src/test/kotlin/fi/hsl/jore4/hastus/test/ObjectMapperTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/test/ObjectMapperTest.kt
@@ -38,7 +38,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
 
-@DisplayName("Test the object mapper")
+@DisplayName("Test JacksonObjectMapper")
 class ObjectMapperTest {
 
     private val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
@@ -88,7 +88,7 @@ class ObjectMapperTest {
     )
 
     @Test
-    @DisplayName("When forming JSON")
+    @DisplayName("When parsing JSON")
     fun testJsonForm() {
         val jsonString = """
         {
@@ -108,11 +108,11 @@ class ObjectMapperTest {
     }
 
     @Nested
-    @DisplayName("Mapping to JSON")
-    inner class MappingToJson() {
+    @DisplayName("Test serialising Object types to JSON")
+    inner class TestSerialisingObjectTypesToJson {
 
         @Test
-        fun `test UUID mapping`() {
+        fun `format UUID as JSON`() {
             val value = UUID.randomUUID()
             val formatted = objectMapper.writeValueAsString(UUIDFormat(value))
             val expected = """
@@ -122,7 +122,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test UUIDList mapping`() {
+        fun `format UUIDList as JSON`() {
             val value = listOf(UUID.randomUUID(), UUID.randomUUID())
             val expected = """
             {"uuidList":"{${value[0]},${value[1]}}"}
@@ -132,7 +132,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test date mapping`() {
+        fun `format LocalDate as JSON`() {
             val value = LocalDate.of(2022, 2, 2)
             val expected = """
             {"date":"2022-02-02"}
@@ -142,7 +142,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test offset time mapping`() {
+        fun `format OffsetDateTime as JSON`() {
             val value = OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 4000000, ZoneOffset.UTC)
             val expected = """
             {"offsetDateTime":"2022-02-02 01:02:03.004 +0000"}
@@ -152,7 +152,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test IJSONB mapping`() {
+        fun `format IJSONB as JSON`() {
             val value = IJSONB(mapOf("first" to "value", "second" to "other"))
             val expected = """
             {"ijsonb":{"first":"value","second":"other"}}
@@ -162,7 +162,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test coordinate mapping`() {
+        fun `format Coordinate as GeoJSON`() {
             val value = Coordinate(1.0, 2.0)
             val expected = """
             {"coordinate":{"type":"Point","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[${value.x},${value.y},0.0]}}
@@ -172,7 +172,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test duration mapping`() {
+        fun `format Duration as JSON`() {
             val value: Duration = 4.hours
             val expected = """
             {"duration":"${value.toIsoString()}"}
@@ -183,11 +183,11 @@ class ObjectMapperTest {
     }
 
     @Nested
-    @DisplayName("Mapping from JSON")
-    inner class MappingFromJson() {
+    @DisplayName("Test deserialising Object types from JSON")
+    inner class TestDeserialisingObjectTypesFromJson() {
 
         @Test
-        fun `test UUID mapping`() {
+        fun `parse UUID from JSON`() {
             val value = UUID.randomUUID()
             val jsonString = """
             {
@@ -199,7 +199,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test UUIDList mapping`() {
+        fun `parse UUIDList from JSON`() {
             val value = listOf(UUID.randomUUID(), UUID.randomUUID())
             val jsonString = """
             {
@@ -211,7 +211,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test date mapping`() {
+        fun `parse LocalDate from JSON`() {
             val value = LocalDate.of(2022, 2, 2)
             val jsonString = """
             {
@@ -223,7 +223,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test offset time mapping`() {
+        fun `parse OffsetDateTime from JSON`() {
             val value = OffsetDateTime.of(2022, 2, 2, 1, 2, 3, 4000000, ZoneOffset.UTC)
             val jsonString = """
             {
@@ -235,7 +235,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test IJSONB mapping`() {
+        fun `parse IJSONB from JSON`() {
             val value = mapOf("first" to "value", "second" to "other")
             val jsonString = """
             {
@@ -250,7 +250,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test coordinate mapping`() {
+        fun `parse Coordinate from GeoJSON`() {
             val value = Coordinate(1.0, 2.0)
             val jsonString = """
              {
@@ -275,7 +275,7 @@ class ObjectMapperTest {
         }
 
         @Test
-        fun `test duration mapping`() {
+        fun `parse Duration from JSON`() {
             val value: Duration = 4.hours
             val jsonString = """
             {


### PR DESCRIPTION
It turns out that GraphQL responses have a variable number of decimals in the timestamps in terms of fractions of seconds. This happens because the trailing zeros are removed from the decimal part.

A fix is needed to support variable number of digits (0-3) in the decimal part.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/35)
<!-- Reviewable:end -->
