### PR TITLE
Fix persisting vehicle type while saving vehicle schedule frame

### DIFF
--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/jore/JoreBlock.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/jore/JoreBlock.kt
@@ -9,13 +9,13 @@ import kotlin.time.Duration
  * @property journeyName Displayed name for the block
  * @property preparingTime Preparing time
  * @property finishingTime Finishing time
- * @property vehicleType Vehicle type as the UUID key in database
+ * @property vehicleTypeId The identifier of the vehicle type (as UUID key in database)
  * @property vehicleJourneys List of vehicle journeys in the block
  */
 data class JoreBlock(
     val journeyName: String,
     val preparingTime: Duration,
     val finishingTime: Duration,
-    val vehicleType: UUID,
+    val vehicleTypeId: UUID,
     val vehicleJourneys: List<JoreVehicleJourney>
 )

--- a/src/main/kotlin/fi/hsl/jore4/hastus/graphql/HasuraClient.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/graphql/HasuraClient.kt
@@ -51,11 +51,7 @@ class HasuraClient(
     ): T {
         return runBlocking {
             LOGGER.debug {
-                "GraphQL request:\n${request.query},\nvariables: ${
-                    objectMapper
-                        .writerWithDefaultPrettyPrinter()
-                        .writeValueAsString(request.variables)
-                }"
+                "GraphQL request:\n${request.query},\nvariables: ${request.variables}"
             }
 
             val queryResponse: GraphQLClientResponse<T> = gqlClient.execute(request) {

--- a/src/main/kotlin/fi/hsl/jore4/hastus/graphql/converter/ConversionsToGraphQL.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/graphql/converter/ConversionsToGraphQL.kt
@@ -81,6 +81,7 @@ object ConversionsToGraphQL {
         return timetables_vehicle_service_block_insert_input(
             finishing_time = OptionalInput.Defined(block.finishingTime.toJavaDuration()),
             preparing_time = OptionalInput.Defined(block.preparingTime.toJavaDuration()),
+            vehicle_type_id = OptionalInput.Defined(block.vehicleTypeId),
             vehicle_journeys = OptionalInput.Defined(
                 timetables_vehicle_journey_vehicle_journey_arr_rel_insert_input(
                     block.vehicleJourneys.map { vehicleJourney ->

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastusTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastusTest.kt
@@ -143,7 +143,7 @@ class ConversionsFromHastusTest {
 
             val block1 = service1.blocks[0]
 
-            assertEquals(VEHICLE_TYPE_1_ID, block1.vehicleType)
+            assertEquals(VEHICLE_TYPE_1_ID, block1.vehicleTypeId)
 
             assertEquals(1, block1.vehicleJourneys.size)
 
@@ -178,7 +178,7 @@ class ConversionsFromHastusTest {
 
             val block2 = service1.blocks[1]
 
-            assertEquals(VEHICLE_TYPE_1_ID, block2.vehicleType)
+            assertEquals(VEHICLE_TYPE_1_ID, block2.vehicleTypeId)
 
             assertEquals(1, block2.vehicleJourneys.size)
 


### PR DESCRIPTION
Fix inserting vehicle schedule frame by including `vehicle_type_id` parameter in blocks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/43)
<!-- Reviewable:end -->
