### PR TITLE
Fix renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,12 +6,12 @@
     // Note: if the rule feels generic enough, should consider adding it to the jore4 default preset
     packageRules: [
         {
-            // restrict spring boot updates to <3 versions for now
+            // restrict spring boot updates to <4 versions for now
             groupName: "spring boot",
             groupSlug: "spring-boot",
             matchPackageNames: ["org.springframework.boot"],
             matchPackagePrefixes: ["org.springframework.boot:"],
-            allowedVersions: "<3",
+            allowedVersions: "<4",
         },
     ],
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.1.5</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
- Fix renovate configuration to not miss Spring Boot 3 updates
- Update Spring Boot from version 3.1.3 to 3.1.5
- Fix setting versions for Jackson dependencies

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/45)
<!-- Reviewable:end -->
