### PR TITLE
Improve log messages

### DIFF
--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByRouteLabelAndDirectionException.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByRouteLabelAndDirectionException.kt
@@ -4,7 +4,9 @@ import fi.hsl.jore4.hastus.data.format.RouteLabelAndDirection
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-class UnmatchedRoutesWithinImportException(routeIdentifiers: List<RouteLabelAndDirection>) : ResponseStatusException(
+class CannotFindJourneyPatternRefByRouteLabelAndDirectionException(
+    routeIdentifiers: List<RouteLabelAndDirection>
+) : ResponseStatusException(
     HttpStatus.BAD_REQUEST,
     "Could not find journey pattern reference for Hastus trips with the following route labels and directions: ${
         routeIdentifiers.joinToString(separator = ",")

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException.kt
@@ -5,10 +5,13 @@ import fi.hsl.jore4.hastus.service.exporting.ConversionsToHastus
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-class NoJourneyPatternRefMatchesHastusTripStopsException(message: String) : ResponseStatusException(
+class CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException(
+    message: String
+) : ResponseStatusException(
     HttpStatus.BAD_REQUEST,
     message
 ) {
+
     constructor(
         routeIdentifier: RouteLabelAndDirection,
         stopLabels: List<String>,

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByStopPointLabelsException.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByStopPointLabelsException.kt
@@ -1,0 +1,30 @@
+package fi.hsl.jore4.hastus.service.importing
+
+import fi.hsl.jore4.hastus.data.format.RouteLabelAndDirection
+import fi.hsl.jore4.hastus.service.exporting.ConversionsToHastus
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+
+class CannotFindJourneyPatternRefByStopPointLabelsException(
+    message: String
+) : ResponseStatusException(
+    HttpStatus.BAD_REQUEST,
+    message
+) {
+
+    constructor(
+        routeIdentifier: RouteLabelAndDirection,
+        stopLabels: List<String>
+    ) : this(
+        """
+        Could not find matching journey pattern reference whose stop points correspond to the Hastus trip.
+
+        Trip label: ${routeIdentifier.routeLabel},
+        Trip direction: ${
+            // This is safe to call here. Possible exceptions in conversions have already taken place.
+            ConversionsToHastus.convertRouteDirection(routeIdentifier.direction)
+        },
+        Stop points: $stopLabels
+        """.trimIndent()
+    )
+}

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByTimingPlaceLabelsException.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByTimingPlaceLabelsException.kt
@@ -5,7 +5,7 @@ import fi.hsl.jore4.hastus.service.exporting.ConversionsToHastus
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-class CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException(
+class CannotFindJourneyPatternRefByTimingPlaceLabelsException(
     message: String
 ) : ResponseStatusException(
     HttpStatus.BAD_REQUEST,
@@ -18,7 +18,7 @@ class CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException(
         placeCodes: List<String?>
     ) : this(
         """
-        No journey pattern reference was found whose stop points correspond to the Hastus trip.
+        Could not find matching journey pattern reference whose timing place labels correspond to the Hastus trip.
 
         Trip label: ${routeIdentifier.routeLabel},
         Trip direction: ${

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastus.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastus.kt
@@ -178,7 +178,8 @@ object ConversionsFromHastus {
                 // Should never happen during application runtime because journeyPatternRefIndex is
                 // expected to be complete at this point. Possible failures should have occurred
                 // earlier in the processing chain. Hence, logging as an error.
-                val exception = UnmatchedRoutesWithinImportException(listOf(routeLabelAndDirection))
+                val exception =
+                    CannotFindJourneyPatternRefByRouteLabelAndDirectionException(listOf(routeLabelAndDirection))
                 LOGGER.error(exception.message)
                 throw exception
             }
@@ -200,7 +201,7 @@ object ConversionsFromHastus {
                             unknownStopLabels.joinToString(prefix = "'", separator = ",", postfix = "'")
                         }"
                     LOGGER.error(errorMessage)
-                    throw NoJourneyPatternRefMatchesHastusTripStopsException(errorMessage)
+                    throw CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException(errorMessage)
                 }
             }
 

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastus.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastus.kt
@@ -201,7 +201,7 @@ object ConversionsFromHastus {
                             unknownStopLabels.joinToString(prefix = "'", separator = ",", postfix = "'")
                         }"
                     LOGGER.error(errorMessage)
-                    throw CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException(errorMessage)
+                    throw CannotFindJourneyPatternRefByStopPointLabelsException(errorMessage)
                 }
             }
 

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ImportService.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ImportService.kt
@@ -129,7 +129,7 @@ class ImportService(private val graphQLServiceFactory: GraphQLServiceFactory) {
                             joreStopLabels == hastusStopLabels && joreTimingPlaceLabels == hastusTimingPlaceLabels
                         }
                         ?: run {
-                            val exception = NoJourneyPatternRefMatchesHastusTripStopsException(
+                            val exception = CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException(
                                 hastusRouteLabelAndDirection,
                                 hastusStopLabels,
                                 hastusTimingPlaceLabels
@@ -153,7 +153,9 @@ class ImportService(private val graphQLServiceFactory: GraphQLServiceFactory) {
                 .sorted()
 
             if (missingRouteLabelsAndDirections.isNotEmpty()) {
-                val exception = UnmatchedRoutesWithinImportException(missingRouteLabelsAndDirections)
+                val exception = CannotFindJourneyPatternRefByRouteLabelAndDirectionException(
+                    missingRouteLabelsAndDirections
+                )
                 LOGGER.warn(exception.message)
                 throw exception
             }

--- a/src/test/kotlin/fi/hsl/jore4/hastus/api/ImportControllerTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/api/ImportControllerTest.kt
@@ -5,10 +5,10 @@ import fi.hsl.jore4.hastus.Constants.MIME_TYPE_CSV
 import fi.hsl.jore4.hastus.data.format.JoreRouteDirection
 import fi.hsl.jore4.hastus.data.format.RouteLabelAndDirection
 import fi.hsl.jore4.hastus.graphql.converter.GraphQLAuthenticationFailedException
+import fi.hsl.jore4.hastus.service.importing.CannotFindJourneyPatternRefByRouteLabelAndDirectionException
+import fi.hsl.jore4.hastus.service.importing.CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException
 import fi.hsl.jore4.hastus.service.importing.ImportService
 import fi.hsl.jore4.hastus.service.importing.InvalidHastusDataException
-import fi.hsl.jore4.hastus.service.importing.NoJourneyPatternRefMatchesHastusTripStopsException
-import fi.hsl.jore4.hastus.service.importing.UnmatchedRoutesWithinImportException
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
@@ -106,7 +106,7 @@ class ImportControllerTest @Autowired constructor(
     fun `returns 400 when there are unmatched routes in Hastus data`() {
         every {
             importService.importTimetablesFromCsv(any(), any())
-        } throws UnmatchedRoutesWithinImportException(
+        } throws CannotFindJourneyPatternRefByRouteLabelAndDirectionException(
             listOf(
                 RouteLabelAndDirection("123", JoreRouteDirection.OUTBOUND),
                 RouteLabelAndDirection("456", JoreRouteDirection.INBOUND)
@@ -131,7 +131,7 @@ class ImportControllerTest @Autowired constructor(
     fun `returns 400 when no journey pattern reference matches any trip record in Hastus data`() {
         every {
             importService.importTimetablesFromCsv(any(), any())
-        } throws NoJourneyPatternRefMatchesHastusTripStopsException(
+        } throws CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException(
             RouteLabelAndDirection("123", JoreRouteDirection.OUTBOUND),
             listOf("H1000", "H1001", "H1002"),
             listOf("1PLACE", null, "2PLACE")

--- a/src/test/kotlin/fi/hsl/jore4/hastus/api/ImportControllerTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/api/ImportControllerTest.kt
@@ -22,8 +22,9 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.ResultMatcher
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -48,12 +49,12 @@ class ImportControllerTest @Autowired constructor(
 
         return mockMvc
             .perform(
-                MockMvcRequestBuilders.post("/import")
+                post("/import")
                     .headers(hasuraHeaders)
                     .contentType(MIME_TYPE_CSV)
                     .content(csv)
             )
-            .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
     }
 
     @Test
@@ -65,9 +66,9 @@ class ImportControllerTest @Autowired constructor(
         } answers { resultVehicleScheduleFrameId }
 
         executeImportTimetablesRequest("<some_csv_content>")
-            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(status().isOk)
             .andExpect(
-                MockMvcResultMatchers.content().json(
+                content().json(
                     """
                     {
                       "vehicleScheduleFrameId": $resultVehicleScheduleFrameId
@@ -91,7 +92,7 @@ class ImportControllerTest @Autowired constructor(
         } throws InvalidHastusDataException(resultErrorMessage)
 
         executeImportTimetablesRequest("<invalid_csv_content>")
-            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+            .andExpect(status().isBadRequest)
             .andExpect(
                 constructExpectedErrorBody(resultErrorMessage)
             )
@@ -113,7 +114,7 @@ class ImportControllerTest @Autowired constructor(
         )
 
         executeImportTimetablesRequest("<csv_content>")
-            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+            .andExpect(status().isBadRequest)
             .andExpect(
                 constructExpectedErrorBody(
                     "Could not find journey pattern reference for Hastus trips with the following route " +
@@ -137,7 +138,7 @@ class ImportControllerTest @Autowired constructor(
         )
 
         executeImportTimetablesRequest("<csv_content>")
-            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+            .andExpect(status().isBadRequest)
             .andExpect(
                 constructExpectedErrorBody(
                     """
@@ -165,7 +166,7 @@ class ImportControllerTest @Autowired constructor(
         } throws GraphQLAuthenticationFailedException(resultErrorMessage)
 
         executeImportTimetablesRequest("<csv_content>")
-            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andExpect(status().isForbidden)
             .andExpect(
                 constructExpectedErrorBody(resultErrorMessage)
             )
@@ -184,7 +185,7 @@ class ImportControllerTest @Autowired constructor(
         } throws Exception(resultErrorMessage)
 
         executeImportTimetablesRequest("<csv_content>")
-            .andExpect(MockMvcResultMatchers.status().isInternalServerError)
+            .andExpect(status().isInternalServerError)
             .andExpect(
                 constructExpectedErrorBody(resultErrorMessage)
             )
@@ -196,7 +197,7 @@ class ImportControllerTest @Autowired constructor(
 
     companion object {
         private fun constructExpectedErrorBody(errorMessage: String): ResultMatcher {
-            return MockMvcResultMatchers.content().json(
+            return content().json(
                 """
                 {
                     "reason": "$errorMessage"

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastusTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastusTest.kt
@@ -260,7 +260,7 @@ class ConversionsFromHastusTest {
                 generateTripStopRecord("trip1", "stop3", "0530", "T", "")
             )
 
-            val exception = assertFailsWith<CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException> {
+            val exception = assertFailsWith<CannotFindJourneyPatternRefByStopPointLabelsException> {
                 ConversionsFromHastus.convertHastusDataToJore(
                     hastusData,
                     vehicleTypeIndex,

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastusTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastusTest.kt
@@ -260,7 +260,7 @@ class ConversionsFromHastusTest {
                 generateTripStopRecord("trip1", "stop3", "0530", "T", "")
             )
 
-            val exception = assertFailsWith<NoJourneyPatternRefMatchesHastusTripStopsException> {
+            val exception = assertFailsWith<CannotFindJourneyPatternRefByStopLabelsAndTimingPointLabelsException> {
                 ConversionsFromHastus.convertHastusDataToJore(
                     hastusData,
                     vehicleTypeIndex,


### PR DESCRIPTION
Refactor `journey_pattern_ref`-matching logic in import feature to improve error messages.

Use separate error messages in cases where (1) the journey pattern reference cannot be found by matching the stop point labels or (2) the journey pattern reference cannot be found by matching the timing place codes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/48)
<!-- Reviewable:end -->
