### PR TITLE
Fix temporal filtering logic in import feature

### DIFF
--- a/src/main/kotlin/fi/hsl/jore4/hastus/graphql/GraphQLService.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/graphql/GraphQLService.kt
@@ -230,14 +230,14 @@ class GraphQLService(
 
     fun getJourneyPatternReferences(
         routeLabels: Collection<String>,
-        validityStart: LocalDate,
-        validityEnd: LocalDate
+        validityStart: LocalDate
     ): List<JoreJourneyPatternRef> {
+        // It is required that the route referenced by the journey pattern reference must be valid
+        // before (or at) the start date of the Hastus booking record.
         val journeyPatternRefsQuery = JourneyPatternRefs(
             variables = JourneyPatternRefs.Variables(
                 route_labels = routeLabels.toList(),
-                validity_start = validityStart,
-                validity_end = validityEnd
+                validity_start = validityStart
             )
         )
 

--- a/src/main/resources/graphql/journeypatternrefs.graphql
+++ b/src/main/resources/graphql/journeypatternrefs.graphql
@@ -1,7 +1,6 @@
 query JourneyPatternRefs(
   $route_labels: [String!]!,
-  $validity_start: date!,
-  $validity_end: date!
+  $validity_start: date!
 ) {
   timetables {
     timetables_journey_pattern_journey_pattern_ref(
@@ -12,12 +11,6 @@ query JourneyPatternRefs(
             _or: [
               { route_validity_start: { _is_null: true } }
               { route_validity_start: { _lte: $validity_start } }
-            ]
-          }
-          {
-            _or: [
-              { route_validity_end: { _is_null: true } }
-              { route_validity_end: { _gte: $validity_end } }
             ]
           }
         ]


### PR DESCRIPTION
Fix possible bug in selecting `journey_pattern_ref` when importing timetables.

Previously, it was required that the validity period of the exported route had to extend beyond the Hastus booking record. This causes potential problems when the route being exported is about to expire and a new version already exists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/50)
<!-- Reviewable:end -->
