### PR TITLE
Fix conversion of Hastus route variant ID in CSV export.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>fi.hsl.jore4</groupId>
     <artifactId>hastus</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <name>Jore4 Hastus Server</name>
     <description>Jore4 hastus import/export server</description>
 

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/format/JoreRouteDirection.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/format/JoreRouteDirection.kt
@@ -14,6 +14,13 @@ enum class JoreRouteDirection {
     SOUTHBOUND,
     WESTBOUND;
 
+    val wellKnownNumber: Int?
+        get() = when (this) {
+            OUTBOUND -> 1
+            INBOUND -> 2
+            else -> null
+        }
+
     fun toGraphQLInNetworkScope(): timetables_route_direction_enum = when (this) {
         ANTICLOCKWISE -> timetables_route_direction_enum.ANTICLOCKWISE
         CLOCKWISE -> timetables_route_direction_enum.CLOCKWISE

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/ApplicationRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/ApplicationRecord.kt
@@ -29,7 +29,5 @@ data class ApplicationRecord(
         jobTime = LocalTime.parse(elements[5].substring(0, 6), timeFormatter())
     )
 
-    override fun getFields(): List<Any> {
-        return listOf()
-    }
+    override fun getFields(): List<Any> = emptyList()
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/BlockRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/BlockRecord.kt
@@ -38,7 +38,5 @@ data class BlockRecord(
         vehicleType = parseToInt(elements[9])
     )
 
-    override fun getFields(): List<Any> {
-        return listOf()
-    }
+    override fun getFields(): List<Any> = emptyList()
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/BookingRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/BookingRecord.kt
@@ -34,7 +34,5 @@ data class BookingRecord(
         contract = elements[7]
     )
 
-    override fun getFields(): List<Any> {
-        return listOf()
-    }
+    override fun getFields(): List<Any> = emptyList()
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/Place.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/Place.kt
@@ -12,7 +12,5 @@ data class Place(
     private val description: String
 ) : HastusData() {
 
-    override fun getFields(): List<Any> {
-        return listOf(identifier, description)
-    }
+    override fun getFields(): List<Any> = listOf(identifier, description)
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/Route.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/Route.kt
@@ -18,7 +18,5 @@ data class Route(
     private val serviceMode: Int
 ) : HastusData() {
 
-    override fun getFields(): List<Any> {
-        return listOf(identifier, description, serviceType, direction, serviceMode)
-    }
+    override fun getFields(): List<Any> = listOf(identifier, description, serviceType, direction, serviceMode)
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/RouteVariant.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/RouteVariant.kt
@@ -20,7 +20,6 @@ data class RouteVariant(
     private val routeId: String
 ) : HastusData() {
 
-    override fun getFields(): List<Any> {
-        return listOf(identifier, description, direction, reversible, routeIdAndVariantId, routeId)
-    }
+    override fun getFields(): List<Any> =
+        listOf(identifier, description, direction, reversible, routeIdAndVariantId, routeId)
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/RouteVariantPoint.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/RouteVariantPoint.kt
@@ -35,15 +35,13 @@ data class RouteVariantPoint(
         }
     }
 
-    override fun getFields(): List<Any> {
-        return listOf(
-            place ?: "", // null to empty string
-            specTpDistance ?: "", // empty string instead of decimal number if distance not given
-            isTimingPoint,
-            allowLoadTime,
-            regulatedTp,
-            stopLabel,
-            routeIdAndVariantId
-        )
-    }
+    override fun getFields(): List<Any> = listOf(
+        place ?: "", // null to empty string
+        specTpDistance ?: "", // empty string instead of decimal number if distance not given
+        isTimingPoint,
+        allowLoadTime,
+        regulatedTp,
+        stopLabel,
+        routeIdAndVariantId
+    )
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/Stop.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/Stop.kt
@@ -5,7 +5,7 @@ import fi.hsl.jore4.hastus.data.format.NumberWithAccuracy
 /**
  * Hastus Stop point representing a Jore4 scheduled stop point
  *
- * @property identifier Stop label as a 7 numbers long string NNNNNNN
+ * @property identifier Stop label
  * @property platform Platform number of the stop. Formatted as two numbers NN
  * @property descriptionFinnish Stop name in Finnish
  * @property descriptionSwedish Stop name in Swedish

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/Stop.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/Stop.kt
@@ -30,18 +30,16 @@ data class Stop(
     private val shortIdentifier: String
 ) : HastusData() {
 
-    override fun getFields(): List<Any> {
-        return listOf(
-            identifier,
-            platform,
-            descriptionFinnish,
-            descriptionSwedish,
-            streetFinnish,
-            streetSwedish,
-            place ?: "",
-            gpsX,
-            gpsY,
-            shortIdentifier
-        )
-    }
+    override fun getFields(): List<Any> = listOf(
+        identifier,
+        platform,
+        descriptionFinnish,
+        descriptionSwedish,
+        streetFinnish,
+        streetSwedish,
+        place ?: "",
+        gpsX,
+        gpsY,
+        shortIdentifier
+    )
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/StopDistance.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/StopDistance.kt
@@ -16,12 +16,10 @@ data class StopDistance(
     val editedDistance: Int
 ) : HastusData() {
 
-    override fun getFields(): List<Any> {
-        return listOf(
-            stopStart,
-            stopEnd,
-            baseInService,
-            editedDistance
-        )
-    }
+    override fun getFields(): List<Any> = listOf(
+        stopStart,
+        stopEnd,
+        baseInService,
+        editedDistance
+    )
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripRecord.kt
@@ -77,7 +77,5 @@ data class TripRecord(
         isExtraTrip = parseToBoolean(elements[22])
     )
 
-    override fun getFields(): List<Any> {
-        return listOf()
-    }
+    override fun getFields(): List<Any> = emptyList()
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripStopRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripStopRecord.kt
@@ -48,7 +48,5 @@ data class TripStopRecord(
         note = elements[11]
     )
 
-    override fun getFields(): List<Any> {
-        return listOf()
-    }
+    override fun getFields(): List<Any> = emptyList()
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripStopRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripStopRecord.kt
@@ -13,8 +13,8 @@ package fi.hsl.jore4.hastus.data.hastus
  * @property passingTime Passing time for the stop point
  * @property distanceFromPreviousStop Distance from the previous timing point in meters. Null, if
  * this stop point is not a timing point.
- * @property stopType Type of the stop point. 'R' on timing places, 'T' on first and last stop,
- * otherwise empty
+ * @property stopType Type of the stop point. 'R' on timing places, 'T' on the first and last stop
+ * point, otherwise empty
  * @property note Used to mark a regulated timing point. 'a' to mark leaving time, 't' to mark
  * arrival time
  *

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/VehicleScheduleRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/VehicleScheduleRecord.kt
@@ -38,7 +38,5 @@ data class VehicleScheduleRecord(
         editTime = LocalTime.parse(elements[8], timeFormatter())
     )
 
-    override fun getFields(): List<Any> {
-        return listOf()
-    }
+    override fun getFields(): List<Any> = emptyList()
 }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/VehicleScheduleRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/VehicleScheduleRecord.kt
@@ -9,12 +9,12 @@ import java.time.LocalTime
  * @property name Displayed name for the vehicle schedule
  * @property scheduleType Day type
  * @property scenario Hastus scenario number
- * @property owner Owner of this shcedule
+ * @property owner Owner of this schedule
  * @property startDate Start date for the vehicle schedule
  * @property endDate End date for the vehicle schedule
  * @property editDate Date when this was last edited
  * @property editTime Time when this was last edited
- * @constructor Create a vehicle scheduel record from a list of strings
+ * @constructor Create a vehicle schedule record from a list of strings
  */
 data class VehicleScheduleRecord(
     val name: String,

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/jore/JoreRoute.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/jore/JoreRoute.kt
@@ -18,7 +18,7 @@ data class JoreRoute(
     val validityEnd: LocalDate?,
     val typeOfLine: String,
     val journeyPatternId: UUID,
-    val stopsOnRoute: List<JoreRouteScheduledStop>
+    val stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern>
 ) {
     val uniqueLabel: String
         get() = "$label${

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/jore/JoreStopPointInJourneyPattern.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/jore/JoreStopPointInJourneyPattern.kt
@@ -1,6 +1,6 @@
 package fi.hsl.jore4.hastus.data.jore
 
-data class JoreRouteScheduledStop(
+data class JoreStopPointInJourneyPattern(
     val stopLabel: String,
     val stopSequenceNumber: Int,
     val timingPlaceCode: String?,

--- a/src/main/kotlin/fi/hsl/jore4/hastus/graphql/GraphQLService.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/graphql/GraphQLService.kt
@@ -209,7 +209,7 @@ class GraphQLService(
                         route_validity_end = OptionalInput.Defined(route.validityEnd),
                         scheduled_stop_point_in_journey_pattern_refs = OptionalInput.Defined(
                             timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_arr_rel_insert_input(
-                                route.stopsOnRoute.map(ConversionsToGraphQL::mapToGraphQL)
+                                route.stopPointsInJourneyPattern.map(ConversionsToGraphQL::mapToGraphQL)
                             )
                         )
                     )

--- a/src/main/kotlin/fi/hsl/jore4/hastus/graphql/converter/ConversionsFromGraphQL.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/graphql/converter/ConversionsFromGraphQL.kt
@@ -4,7 +4,7 @@ import fi.hsl.jore4.hastus.Constants.LANG_FINNISH
 import fi.hsl.jore4.hastus.data.format.JoreRouteDirection
 import fi.hsl.jore4.hastus.data.jore.JoreLine
 import fi.hsl.jore4.hastus.data.jore.JoreRoute
-import fi.hsl.jore4.hastus.data.jore.JoreRouteScheduledStop
+import fi.hsl.jore4.hastus.data.jore.JoreStopPointInJourneyPattern
 import fi.hsl.jore4.hastus.generated.routeswithhastusdata.journey_pattern_journey_pattern
 import fi.hsl.jore4.hastus.generated.routeswithhastusdata.journey_pattern_scheduled_stop_point_in_journey_pattern
 import fi.hsl.jore4.hastus.generated.routeswithhastusdata.route_line
@@ -44,7 +44,7 @@ object ConversionsFromGraphQL {
     private fun mapToJoreRouteScheduledStop(
         stopInJourneyPattern: journey_pattern_scheduled_stop_point_in_journey_pattern?,
         distanceToNextStop: Double
-    ): JoreRouteScheduledStop {
+    ): JoreStopPointInJourneyPattern {
         if (stopInJourneyPattern == null) {
             throw IllegalStateException("Should not encounter a null journey pattern stop during conversion")
         }
@@ -62,7 +62,7 @@ object ConversionsFromGraphQL {
                 )
             }
 
-        return JoreRouteScheduledStop(
+        return JoreStopPointInJourneyPattern(
             stopLabel,
             stopInJourneyPattern.scheduled_stop_point_sequence,
             maxPriorityStopPoint.timing_place?.label,
@@ -106,7 +106,7 @@ object ConversionsFromGraphQL {
             validityEnd = route.validity_end,
             typeOfLine = typeOfLine.lowercase(),
             journeyPatternId = journeyPattern.journey_pattern_id,
-            stopsOnRoute = journeyPatternStopsWithNextLabel.map { (journeyPatternStop, nextStopLabel) ->
+            stopPointsInJourneyPattern = journeyPatternStopsWithNextLabel.map { (journeyPatternStop, nextStopLabel) ->
                 val currentStopLabel = journeyPatternStop.scheduled_stop_point_label
                 val getDistanceKey = Pair(currentStopLabel, nextStopLabel)
 

--- a/src/main/kotlin/fi/hsl/jore4/hastus/graphql/converter/ConversionsToGraphQL.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/graphql/converter/ConversionsToGraphQL.kt
@@ -6,7 +6,7 @@ import fi.hsl.jore4.hastus.data.jore.JoreBlock
 import fi.hsl.jore4.hastus.data.jore.JoreJourneyPatternRef
 import fi.hsl.jore4.hastus.data.jore.JoreJourneyPatternStopRef
 import fi.hsl.jore4.hastus.data.jore.JorePassingTime
-import fi.hsl.jore4.hastus.data.jore.JoreRouteScheduledStop
+import fi.hsl.jore4.hastus.data.jore.JoreStopPointInJourneyPattern
 import fi.hsl.jore4.hastus.data.jore.JoreVehicleJourney
 import fi.hsl.jore4.hastus.data.jore.JoreVehicleScheduleFrame
 import fi.hsl.jore4.hastus.data.jore.JoreVehicleService
@@ -26,7 +26,7 @@ import kotlin.time.toJavaDuration
 
 object ConversionsToGraphQL {
 
-    fun mapToGraphQL(stop: JoreRouteScheduledStop) =
+    fun mapToGraphQL(stop: JoreStopPointInJourneyPattern) =
         timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_insert_input(
             scheduled_stop_point_label = OptionalInput.Defined(stop.stopLabel),
             scheduled_stop_point_sequence = OptionalInput.Defined(stop.stopSequenceNumber),

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToHastus.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToHastus.kt
@@ -37,7 +37,7 @@ object ConversionsToHastus {
         joreLineLabel: String
     ): List<IHastusData> {
         return joreRoutes.flatMap { joreRoute ->
-            val routeDirection: Int = convertRouteDirection(joreRoute.direction)
+            val routeDirection: Int = getRouteDirectionAsNumberOrThrow(joreRoute.direction)
             val hastusRouteVariantId: String =
                 joreRoute.variant?.takeIf { it.isNotBlank() } ?: routeDirection.toString()
             val routeUniqueLabel: String = joreRoute.label + hastusRouteVariantId
@@ -61,10 +61,9 @@ object ConversionsToHastus {
         }
     }
 
-    fun convertRouteDirection(routeDirection: JoreRouteDirection): Int = when (routeDirection) {
-        JoreRouteDirection.OUTBOUND -> 1
-        JoreRouteDirection.INBOUND -> 2
-        else -> throw IllegalArgumentException("Cannot convert Jore4 route direction to Hastus: $routeDirection")
+    private fun getRouteDirectionAsNumberOrThrow(routeDirection: JoreRouteDirection): Int {
+        return routeDirection.wellKnownNumber
+            ?: throw IllegalArgumentException("Cannot convert Jore4 route direction to Hastus: $routeDirection")
     }
 
     private fun convertJoreStopPointsInJourneyPatternToHastusRouteVariantPoints(

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToHastus.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToHastus.kt
@@ -37,28 +37,41 @@ object ConversionsToHastus {
         joreLineLabel: String
     ): List<IHastusData> {
         return joreRoutes.flatMap { joreRoute ->
-            val routeDirection: Int = getRouteDirectionAsNumberOrThrow(joreRoute.direction)
             val hastusRouteVariantId: String =
-                joreRoute.variant?.takeIf { it.isNotBlank() } ?: routeDirection.toString()
-            val routeUniqueLabel: String = joreRoute.label + hastusRouteVariantId
+                getHastusRouteVariantId(joreLineLabel, joreRoute.label, joreRoute.variant, joreRoute.direction)
+            val hastusRouteIdAndVariantId: String = joreLineLabel + hastusRouteVariantId
+            val hastusRouteDirection: Int = getRouteDirectionAsNumberOrThrow(joreRoute.direction) - 1
 
-            val routeVariant = RouteVariant(
+            val hastusRouteVariant = RouteVariant(
                 identifier = hastusRouteVariantId,
                 description = joreRoute.name,
-                direction = routeDirection - 1,
+                direction = hastusRouteDirection,
                 reversible = joreRoute.reversible,
-                routeIdAndVariantId = routeUniqueLabel,
+                routeIdAndVariantId = hastusRouteIdAndVariantId,
                 routeId = joreLineLabel
             )
 
-            val routeVariantPoints: List<RouteVariantPoint> =
+            val hastusRouteVariantPoints: List<RouteVariantPoint> =
                 convertJoreStopPointsInJourneyPatternToHastusRouteVariantPoints(
                     joreRoute.stopPointsInJourneyPattern,
-                    routeUniqueLabel
+                    hastusRouteIdAndVariantId
                 )
 
-            listOf(routeVariant) + routeVariantPoints
+            listOf(hastusRouteVariant) + hastusRouteVariantPoints
         }
+    }
+
+    fun getHastusRouteVariantId(
+        joreLineLabel: String,
+        joreRouteLabel: String,
+        variant: String?,
+        direction: JoreRouteDirection
+    ): String {
+        val letterVariant: String = joreRouteLabel.substringAfter(joreLineLabel)
+        val numberVariant: String = variant ?: ""
+        val routeDirection: Int = getRouteDirectionAsNumberOrThrow(direction)
+
+        return "$letterVariant$numberVariant$routeDirection"
     }
 
     private fun getRouteDirectionAsNumberOrThrow(routeDirection: JoreRouteDirection): Int {

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToHastus.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToHastus.kt
@@ -12,8 +12,8 @@ import fi.hsl.jore4.hastus.data.hastus.StopDistance
 import fi.hsl.jore4.hastus.data.jore.JoreDistanceBetweenTwoStopPoints
 import fi.hsl.jore4.hastus.data.jore.JoreLine
 import fi.hsl.jore4.hastus.data.jore.JoreRoute
-import fi.hsl.jore4.hastus.data.jore.JoreRouteScheduledStop
 import fi.hsl.jore4.hastus.data.jore.JoreScheduledStop
+import fi.hsl.jore4.hastus.data.jore.JoreStopPointInJourneyPattern
 import fi.hsl.jore4.hastus.data.jore.JoreTimingPlace
 
 object ConversionsToHastus {
@@ -53,7 +53,7 @@ object ConversionsToHastus {
 
             val routeVariantPoints: List<RouteVariantPoint> =
                 convertJoreStopPointsInJourneyPatternToHastusRouteVariantPoints(
-                    joreRoute.stopsOnRoute,
+                    joreRoute.stopPointsInJourneyPattern,
                     routeUniqueLabel
                 )
 
@@ -68,7 +68,7 @@ object ConversionsToHastus {
     }
 
     private fun convertJoreStopPointsInJourneyPatternToHastusRouteVariantPoints(
-        joreStopPointsInJourneyPattern: List<JoreRouteScheduledStop>,
+        joreStopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern>,
         hastusRouteIdAndVariantId: String
     ): List<RouteVariantPoint> {
         var firstTimingPointEncountered = false

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/ExportService.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/ExportService.kt
@@ -61,7 +61,7 @@ class ExportService(
 
         val hastusData: List<IHastusData> =
             ConversionsToHastus.convertJoreLinesToHastus(lines) +
-                ConversionsToHastus.convertJoreStopsToHastus(stopPoints) +
+                ConversionsToHastus.convertJoreStopPointsToHastus(stopPoints) +
                 ConversionsToHastus.convertJoreTimingPlacesToHastus(timingPlaces) +
                 ConversionsToHastus.convertDistancesBetweenStopPointsToHastus(distancesBetweenStopPoints)
 

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/validation/ExportStopPointsValidator.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/exporting/validation/ExportStopPointsValidator.kt
@@ -1,7 +1,7 @@
 package fi.hsl.jore4.hastus.service.exporting.validation
 
 import fi.hsl.jore4.hastus.data.jore.JoreLine
-import fi.hsl.jore4.hastus.data.jore.JoreRouteScheduledStop
+import fi.hsl.jore4.hastus.data.jore.JoreStopPointInJourneyPattern
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -33,7 +33,7 @@ class ExportStopPointsValidator(
     override fun validateLine(line: JoreLine) {
         line.routes.forEach { route ->
 
-            if (route.stopsOnRoute.size < 2) {
+            if (route.stopPointsInJourneyPattern.size < 2) {
                 LOGGER.warn {
                     "Journey pattern for route ${route.label} contains less than two stop points"
                 }
@@ -42,7 +42,7 @@ class ExportStopPointsValidator(
                 }
             }
 
-            val firstStopOnRoute: JoreRouteScheduledStop = route.stopsOnRoute.first()
+            val firstStopOnRoute: JoreStopPointInJourneyPattern = route.stopPointsInJourneyPattern.first()
 
             if (!firstStopOnRoute.isUsedAsTimingPoint || firstStopOnRoute.timingPlaceCode == null) {
                 LOGGER.warn {
@@ -54,7 +54,7 @@ class ExportStopPointsValidator(
                 }
             }
 
-            val lastStopOnRoute: JoreRouteScheduledStop = route.stopsOnRoute.last()
+            val lastStopOnRoute: JoreStopPointInJourneyPattern = route.stopPointsInJourneyPattern.last()
 
             if (!lastStopOnRoute.isUsedAsTimingPoint || lastStopOnRoute.timingPlaceCode == null) {
                 LOGGER.warn {

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByStopPointLabelsException.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByStopPointLabelsException.kt
@@ -1,7 +1,6 @@
 package fi.hsl.jore4.hastus.service.importing
 
 import fi.hsl.jore4.hastus.data.format.RouteLabelAndDirection
-import fi.hsl.jore4.hastus.service.exporting.ConversionsToHastus
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
@@ -20,10 +19,7 @@ class CannotFindJourneyPatternRefByStopPointLabelsException(
         Could not find matching journey pattern reference whose stop points correspond to the Hastus trip.
 
         Trip label: ${routeIdentifier.routeLabel},
-        Trip direction: ${
-            // This is safe to call here. Possible exceptions in conversions have already taken place.
-            ConversionsToHastus.convertRouteDirection(routeIdentifier.direction)
-        },
+        Trip direction: ${routeIdentifier.direction.wellKnownNumber},
         Stop points: $stopLabels
         """.trimIndent()
     )

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByTimingPlaceLabelsException.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/CannotFindJourneyPatternRefByTimingPlaceLabelsException.kt
@@ -1,7 +1,6 @@
 package fi.hsl.jore4.hastus.service.importing
 
 import fi.hsl.jore4.hastus.data.format.RouteLabelAndDirection
-import fi.hsl.jore4.hastus.service.exporting.ConversionsToHastus
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
@@ -21,10 +20,7 @@ class CannotFindJourneyPatternRefByTimingPlaceLabelsException(
         Could not find matching journey pattern reference whose timing place labels correspond to the Hastus trip.
 
         Trip label: ${routeIdentifier.routeLabel},
-        Trip direction: ${
-            // This is safe to call here. Possible exceptions in conversions have already taken place.
-            ConversionsToHastus.convertRouteDirection(routeIdentifier.direction)
-        },
+        Trip direction: ${routeIdentifier.direction.wellKnownNumber},
         Stop points: $stopLabels,
         Place codes: ${placeCodes.map { /* replace nulls with empty strings */ it ?: "" }}
         """.trimIndent()

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToCsvTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToCsvTest.kt
@@ -265,7 +265,7 @@ class ConversionsToCsvTest {
             )
         )
 
-        val hastusStops: List<Stop> = ConversionsToHastus.convertJoreStopsToHastus(stopPoints)
+        val hastusStops: List<Stop> = ConversionsToHastus.convertJoreStopPointsToHastus(stopPoints)
 
         assertEquals(expectedCsv, CsvWriter().transformToCsv(hastusStops))
     }

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToCsvTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToCsvTest.kt
@@ -7,8 +7,8 @@ import fi.hsl.jore4.hastus.data.hastus.Place
 import fi.hsl.jore4.hastus.data.hastus.Stop
 import fi.hsl.jore4.hastus.data.jore.JoreLine
 import fi.hsl.jore4.hastus.data.jore.JoreRoute
-import fi.hsl.jore4.hastus.data.jore.JoreRouteScheduledStop
 import fi.hsl.jore4.hastus.data.jore.JoreScheduledStop
+import fi.hsl.jore4.hastus.data.jore.JoreStopPointInJourneyPattern
 import fi.hsl.jore4.hastus.data.jore.JoreTimingPlace
 import fi.hsl.jore4.hastus.util.CsvWriter
 import org.junit.jupiter.api.DisplayName
@@ -46,8 +46,8 @@ class ConversionsToCsvTest {
             rvpoint;1KALA;0.750;1;0;0;H1238;65y2
             """.trimIndent()
 
-            val stopPoints = listOf(
-                JoreRouteScheduledStop(
+            val stopPointsInJourneyPattern = listOf(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1234",
                     stopSequenceNumber = 1,
                     timingPlaceCode = "1AACKT",
@@ -56,7 +56,7 @@ class ConversionsToCsvTest {
                     isAllowedLoad = false,
                     distanceToNextStop = 1234.0
                 ),
-                JoreRouteScheduledStop(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1235",
                     stopSequenceNumber = 2,
                     timingPlaceCode = "1ELIMK",
@@ -65,7 +65,7 @@ class ConversionsToCsvTest {
                     isAllowedLoad = false,
                     distanceToNextStop = 1000.0
                 ),
-                JoreRouteScheduledStop(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1236",
                     stopSequenceNumber = 3,
                     timingPlaceCode = "1AURLA",
@@ -74,7 +74,7 @@ class ConversionsToCsvTest {
                     isAllowedLoad = true,
                     distanceToNextStop = 250.0
                 ),
-                JoreRouteScheduledStop(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1237",
                     stopSequenceNumber = 4,
                     timingPlaceCode = null,
@@ -83,7 +83,7 @@ class ConversionsToCsvTest {
                     isAllowedLoad = false,
                     distanceToNextStop = 500.0
                 ),
-                JoreRouteScheduledStop(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1238",
                     stopSequenceNumber = 5,
                     timingPlaceCode = "1KALA",
@@ -112,7 +112,7 @@ class ConversionsToCsvTest {
                         validityEnd = LocalDate.of(2050, 12, 31),
                         typeOfLine = typeOfLine,
                         journeyPatternId = UUID.randomUUID(),
-                        stopsOnRoute = stopPoints
+                        stopPointsInJourneyPattern = stopPointsInJourneyPattern
                     ),
                     JoreRoute(
                         label = "65y",
@@ -124,7 +124,7 @@ class ConversionsToCsvTest {
                         validityEnd = LocalDate.of(2050, 12, 31),
                         typeOfLine = typeOfLine,
                         journeyPatternId = UUID.randomUUID(),
-                        stopsOnRoute = stopPoints
+                        stopPointsInJourneyPattern = stopPointsInJourneyPattern
                     )
                 )
             )
@@ -145,8 +145,8 @@ class ConversionsToCsvTest {
             rvpoint;;;0;0;0;H1237;65x1
             """.trimIndent()
 
-            val stopPoints = listOf(
-                JoreRouteScheduledStop(
+            val stopPointsInJourneyPattern = listOf(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1234",
                     stopSequenceNumber = 1,
                     timingPlaceCode = "1AACKT",
@@ -155,7 +155,7 @@ class ConversionsToCsvTest {
                     isAllowedLoad = false,
                     distanceToNextStop = 1234.0
                 ),
-                JoreRouteScheduledStop(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1235",
                     stopSequenceNumber = 2,
                     timingPlaceCode = "1ELIMK",
@@ -164,7 +164,7 @@ class ConversionsToCsvTest {
                     isAllowedLoad = false,
                     distanceToNextStop = 1000.0
                 ),
-                JoreRouteScheduledStop(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1236",
                     stopSequenceNumber = 3,
                     timingPlaceCode = "1AURLA",
@@ -173,7 +173,7 @@ class ConversionsToCsvTest {
                     isAllowedLoad = false,
                     distanceToNextStop = 2500.0
                 ),
-                JoreRouteScheduledStop(
+                JoreStopPointInJourneyPattern(
                     stopLabel = "H1237",
                     stopSequenceNumber = 4,
                     timingPlaceCode = "1KALA",
@@ -202,7 +202,7 @@ class ConversionsToCsvTest {
                         validityEnd = LocalDate.of(2050, 12, 31),
                         typeOfLine = typeOfLine,
                         journeyPatternId = UUID.randomUUID(),
-                        stopsOnRoute = stopPoints
+                        stopPointsInJourneyPattern = stopPointsInJourneyPattern
                     )
                 )
             )

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToCsvTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToCsvTest.kt
@@ -38,12 +38,12 @@ class ConversionsToCsvTest {
             rvpoint;1AURLA;2.234;1;1;1;H1236;65x1
             rvpoint;;;0;0;0;H1237;65x1
             rvpoint;1KALA;0.750;1;0;0;H1238;65x1
-            rvariant;2;Reitti A - B 3 FI;0;0;65y2;65
-            rvpoint;1AACKT;0.000;1;0;0;H1234;65y2
-            rvpoint;;;0;0;0;H1235;65y2
-            rvpoint;1AURLA;2.234;1;1;1;H1236;65y2
-            rvpoint;;;0;0;0;H1237;65y2
-            rvpoint;1KALA;0.750;1;0;0;H1238;65y2
+            rvariant;3;Reitti A - B 3 FI;1;0;65y3;65
+            rvpoint;1AACKT;0.000;1;0;0;H1234;65y3
+            rvpoint;;;0;0;0;H1235;65y3
+            rvpoint;1AURLA;2.234;1;1;1;H1236;65y3
+            rvpoint;;;0;0;0;H1237;65y3
+            rvpoint;1KALA;0.750;1;0;0;H1238;65y3
             """.trimIndent()
 
             val stopPointsInJourneyPattern = listOf(
@@ -116,9 +116,9 @@ class ConversionsToCsvTest {
                     ),
                     JoreRoute(
                         label = "65y",
-                        variant = "2",
+                        variant = "3",
                         name = "Reitti A - B 3 FI",
-                        direction = JoreRouteDirection.OUTBOUND,
+                        direction = JoreRouteDirection.INBOUND,
                         reversible = false,
                         validityStart = LocalDate.of(2023, 1, 1),
                         validityEnd = LocalDate.of(2050, 12, 31),

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToCsvTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToCsvTest.kt
@@ -32,18 +32,18 @@ class ConversionsToCsvTest {
         fun `when the first and last stop are timing points`() {
             val expectedCsv = """
             route;65;Rautatientori - Veräjälaakso FI;0;0;0
-            rvariant;1;Reitti A - B FI;0;0;65x1;65
+            rvariant;x1;Reitti A - B FI;0;0;65x1;65
             rvpoint;1AACKT;0.000;1;0;0;H1234;65x1
             rvpoint;;;0;0;0;H1235;65x1
             rvpoint;1AURLA;2.234;1;1;1;H1236;65x1
             rvpoint;;;0;0;0;H1237;65x1
             rvpoint;1KALA;0.750;1;0;0;H1238;65x1
-            rvariant;3;Reitti A - B 3 FI;1;0;65y3;65
-            rvpoint;1AACKT;0.000;1;0;0;H1234;65y3
-            rvpoint;;;0;0;0;H1235;65y3
-            rvpoint;1AURLA;2.234;1;1;1;H1236;65y3
-            rvpoint;;;0;0;0;H1237;65y3
-            rvpoint;1KALA;0.750;1;0;0;H1238;65y3
+            rvariant;y32;Reitti A - B 3 FI;1;0;65y32;65
+            rvpoint;1AACKT;0.000;1;0;0;H1234;65y32
+            rvpoint;;;0;0;0;H1235;65y32
+            rvpoint;1AURLA;2.234;1;1;1;H1236;65y32
+            rvpoint;;;0;0;0;H1237;65y32
+            rvpoint;1KALA;0.750;1;0;0;H1238;65y32
             """.trimIndent()
 
             val stopPointsInJourneyPattern = listOf(
@@ -138,7 +138,7 @@ class ConversionsToCsvTest {
         fun `when the first and last stop are NOT timing points`() {
             val expectedCsv = """
             route;65;Rautatientori - Veräjälaakso FI;0;0;0
-            rvariant;1;Reitti A - B FI;0;0;65x1;65
+            rvariant;x1;Reitti A - B FI;0;0;65x1;65
             rvpoint;;;0;0;0;H1234;65x1
             rvpoint;1ELIMK;0.000;1;0;0;H1235;65x1
             rvpoint;1AURLA;1.000;1;0;1;H1236;65x1

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToHastusTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ConversionsToHastusTest.kt
@@ -1,0 +1,53 @@
+package fi.hsl.jore4.hastus.service.exporting
+
+import fi.hsl.jore4.hastus.data.format.JoreRouteDirection
+import fi.hsl.jore4.hastus.service.exporting.ConversionsToHastus.getHastusRouteVariantId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@DisplayName("Test type conversions from Jore to Hastus")
+class ConversionsToHastusTest {
+
+    @DisplayName("Test method: getHastusRouteVariantId")
+    @Nested
+    inner class TestGetHastusRouteVariantId {
+
+        @Test
+        fun `with basic route`() {
+            assertEquals("1", getHastusRouteVariantId("123", "123", null, JoreRouteDirection.OUTBOUND))
+            assertEquals("2", getHastusRouteVariantId("123", "123", null, JoreRouteDirection.INBOUND))
+        }
+
+        @Test
+        fun `with one-char letter variant`() {
+            assertEquals("B1", getHastusRouteVariantId("123", "123B", null, JoreRouteDirection.OUTBOUND))
+            assertEquals("B2", getHastusRouteVariantId("123", "123B", null, JoreRouteDirection.INBOUND))
+        }
+
+        @Test
+        fun `with two-char letter variant`() {
+            assertEquals("BK1", getHastusRouteVariantId("123", "123BK", null, JoreRouteDirection.OUTBOUND))
+            assertEquals("BK2", getHastusRouteVariantId("123", "123BK", null, JoreRouteDirection.INBOUND))
+        }
+
+        @Test
+        fun `with single digit variant`() {
+            assertEquals("31", getHastusRouteVariantId("123", "123", "3", JoreRouteDirection.OUTBOUND))
+            assertEquals("32", getHastusRouteVariantId("123", "123", "3", JoreRouteDirection.INBOUND))
+        }
+
+        @Test
+        fun `with variant consisting of one letter and a single digit`() {
+            assertEquals("K41", getHastusRouteVariantId("123", "123K", "4", JoreRouteDirection.OUTBOUND))
+            assertEquals("K42", getHastusRouteVariantId("123", "123K", "4", JoreRouteDirection.INBOUND))
+        }
+
+        @Test
+        fun `with variant consisting of two letters and a single digit`() {
+            assertEquals("BK51", getHastusRouteVariantId("123", "123BK", "5", JoreRouteDirection.OUTBOUND))
+            assertEquals("BK52", getHastusRouteVariantId("123", "123BK", "5", JoreRouteDirection.INBOUND))
+        }
+    }
+}

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ExportServiceTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ExportServiceTest.kt
@@ -1,7 +1,7 @@
 package fi.hsl.jore4.hastus.service.exporting
 
 import fi.hsl.jore4.hastus.data.jore.JoreLine
-import fi.hsl.jore4.hastus.data.jore.JoreRouteScheduledStop
+import fi.hsl.jore4.hastus.data.jore.JoreStopPointInJourneyPattern
 import fi.hsl.jore4.hastus.graphql.FetchRoutesResult
 import fi.hsl.jore4.hastus.graphql.GraphQLService
 import fi.hsl.jore4.hastus.graphql.GraphQLServiceFactory
@@ -69,11 +69,11 @@ class ExportServiceTest : ExportTestDataCreator {
 
         @Test
         fun `validation should succeed when the first and the last stop points are timing points`() {
-            val stopPoints: List<JoreRouteScheduledStop> = listOf(
+            val stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern> = listOf(
                 createFirstStopPoint("1KALA"),
                 createLastStopPoint(2, "1ELIEL")
             )
-            val line: JoreLine = createLine(stopPoints)
+            val line: JoreLine = createLine(stopPointsInJourneyPattern)
 
             mockGraphQLService(line)
 
@@ -84,11 +84,11 @@ class ExportServiceTest : ExportTestDataCreator {
 
         @Test
         fun `validation should fail when the first or the last stop point is not a timing point`() {
-            val stopPoints: List<JoreRouteScheduledStop> = listOf(
+            val stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern> = listOf(
                 createFirstStopPoint(null, false),
                 createLastStopPoint(2, "1ELIEL", true)
             )
-            val line: JoreLine = createLine(stopPoints)
+            val line: JoreLine = createLine(stopPointsInJourneyPattern)
 
             mockGraphQLService(line)
 

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ExportTestDataCreator.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/ExportTestDataCreator.kt
@@ -3,13 +3,13 @@ package fi.hsl.jore4.hastus.service.exporting
 import fi.hsl.jore4.hastus.data.format.JoreRouteDirection
 import fi.hsl.jore4.hastus.data.jore.JoreLine
 import fi.hsl.jore4.hastus.data.jore.JoreRoute
-import fi.hsl.jore4.hastus.data.jore.JoreRouteScheduledStop
+import fi.hsl.jore4.hastus.data.jore.JoreStopPointInJourneyPattern
 import java.time.LocalDate
 import java.util.UUID
 
 interface ExportTestDataCreator {
 
-    fun createLine(stopsOnRoute: List<JoreRouteScheduledStop>): JoreLine {
+    fun createLine(stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern>): JoreLine {
         val typeOfLine = "stopping_bus_service"
 
         return JoreLine(
@@ -28,7 +28,7 @@ interface ExportTestDataCreator {
                     validityStart = LocalDate.of(2023, 1, 1),
                     validityEnd = LocalDate.of(2050, 12, 31),
                     journeyPatternId = UUID.randomUUID(),
-                    stopsOnRoute = stopsOnRoute
+                    stopPointsInJourneyPattern = stopPointsInJourneyPattern
                 )
             )
         )
@@ -37,8 +37,8 @@ interface ExportTestDataCreator {
     fun createFirstStopPoint(
         timingPlaceShortName: String?,
         isUsedAsTimingPoint: Boolean = true
-    ): JoreRouteScheduledStop {
-        return JoreRouteScheduledStop(
+    ): JoreStopPointInJourneyPattern {
+        return JoreStopPointInJourneyPattern(
             stopLabel = "H1000",
             stopSequenceNumber = 1,
             timingPlaceCode = timingPlaceShortName,
@@ -53,8 +53,8 @@ interface ExportTestDataCreator {
         stopSequenceNumber: Int,
         timingPlaceShortName: String?,
         isUsedAsTimingPoint: Boolean = true
-    ): JoreRouteScheduledStop {
-        return JoreRouteScheduledStop(
+    ): JoreStopPointInJourneyPattern {
+        return JoreStopPointInJourneyPattern(
             stopLabel = "H9999",
             stopSequenceNumber = stopSequenceNumber,
             timingPlaceCode = timingPlaceShortName,

--- a/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/validation/ExportStopPointsValidatorTest.kt
+++ b/src/test/kotlin/fi/hsl/jore4/hastus/service/exporting/validation/ExportStopPointsValidatorTest.kt
@@ -1,7 +1,7 @@
 package fi.hsl.jore4.hastus.service.exporting.validation
 
 import fi.hsl.jore4.hastus.data.jore.JoreLine
-import fi.hsl.jore4.hastus.data.jore.JoreRouteScheduledStop
+import fi.hsl.jore4.hastus.data.jore.JoreStopPointInJourneyPattern
 import fi.hsl.jore4.hastus.service.exporting.ExportTestDataCreator
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -12,11 +12,11 @@ class ExportStopPointsValidatorTest : ExportTestDataCreator {
 
     @Test
     fun `validation should succeed when the first and the last stop points are timing points`() {
-        val stopPoints: List<JoreRouteScheduledStop> = listOf(
+        val stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern> = listOf(
             createFirstStopPoint("1KALA"),
             createFirstStopPoint("1ELIEL")
         )
-        val line: JoreLine = createLine(stopPoints)
+        val line: JoreLine = createLine(stopPointsInJourneyPattern)
 
         // should not throw exception
         validateLine(line)
@@ -67,11 +67,11 @@ class ExportStopPointsValidatorTest : ExportTestDataCreator {
 
         @Test
         fun `when the first stop point is a timing point but does not have timing place name`() {
-            val stopPoints: List<JoreRouteScheduledStop> = listOf(
+            val stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern> = listOf(
                 createFirstStopPoint(null, true),
                 createLastStopPoint(2, "1ELIEL")
             )
-            val line: JoreLine = createLine(stopPoints)
+            val line: JoreLine = createLine(stopPointsInJourneyPattern)
 
             assertFailsWith<FirstStopNotTimingPointException> {
                 validateLine(line)
@@ -80,11 +80,11 @@ class ExportStopPointsValidatorTest : ExportTestDataCreator {
 
         @Test
         fun `when the first stop point is not a timing point but has timing place name`() {
-            val stopPoints: List<JoreRouteScheduledStop> = listOf(
+            val stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern> = listOf(
                 createFirstStopPoint("1KALA", false),
                 createLastStopPoint(2, "1ELIEL")
             )
-            val line: JoreLine = createLine(stopPoints)
+            val line: JoreLine = createLine(stopPointsInJourneyPattern)
 
             assertFailsWith<FirstStopNotTimingPointException> {
                 validateLine(line)
@@ -118,11 +118,11 @@ class ExportStopPointsValidatorTest : ExportTestDataCreator {
 
         @Test
         fun `when the last stop point is a timing point but does not have timing place name`() {
-            val stopPoints: List<JoreRouteScheduledStop> = listOf(
+            val stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern> = listOf(
                 createFirstStopPoint("1ELIEL"),
                 createLastStopPoint(2, null, true)
             )
-            val line: JoreLine = createLine(stopPoints)
+            val line: JoreLine = createLine(stopPointsInJourneyPattern)
 
             assertFailsWith<LastStopNotTimingPointException> {
                 validateLine(line)
@@ -131,11 +131,11 @@ class ExportStopPointsValidatorTest : ExportTestDataCreator {
 
         @Test
         fun `when the last stop point is not a timing point but has timing place name`() {
-            val stopPoints: List<JoreRouteScheduledStop> = listOf(
+            val stopPointsInJourneyPattern: List<JoreStopPointInJourneyPattern> = listOf(
                 createFirstStopPoint("1KALA"),
                 createLastStopPoint(2, "1ELIEL", false)
             )
-            val line: JoreLine = createLine(stopPoints)
+            val line: JoreLine = createLine(stopPointsInJourneyPattern)
 
             assertFailsWith<LastStopNotTimingPointException> {
                 validateLine(line)


### PR DESCRIPTION
The bug concerned `rvariant` rows in exported CSV files.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/51)
<!-- Reviewable:end -->
