### PR TITLE
Fix multiple bugs in Hastus import

### DIFF
--- a/src/main/kotlin/fi/hsl/jore4/hastus/Constants.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/Constants.kt
@@ -10,7 +10,7 @@ object Constants {
     const val DEFAULT_HASTUS_DATE_FORMAT = "yyyyMMdd"
     const val DEFAULT_HASTUS_TIME_FORMAT = "HHmmss"
 
-    const val MIME_TYPE_CSV = "text/csv"
+    const val MIME_TYPE_CSV = "text/csv;charset=iso-8859-1"
 
     // priorities for network scope in GraphQL
     const val SCHEDULED_STOP_POINT_PRIORITY_DRAFT = 30

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripRecord.kt
@@ -20,7 +20,7 @@ package fi.hsl.jore4.hastus.data.hastus
  * @property tripType2 Duplicated(?) type of the trip. 0 = normal, 1 = pull out, 2 = pull in, 3 = transfer
  * @property note Special note. Value 'p' means it's a friday trip
  * @property note2 Reserved for extra information
- * @property direction Direction. 1 = outbound, 2 = inbound
+ * @property direction Direction. 1 = outbound, 2 = inbound, null = dead run
  * @property vehicleType HSL vehicle type id
  * @property isVehicleTypeMandatory Is vehicle type mandatory
  * @property isBackupTrip Is this a backup trip
@@ -45,7 +45,7 @@ data class TripRecord(
     val tripType2: String, // TODO This field appears to be a duplicate
     val note: String,
     val note2: String,
-    val direction: Int,
+    val direction: Int?,
     val vehicleType: Int,
     val isVehicleTypeMandatory: Boolean,
     val isBackupTrip: Boolean,
@@ -70,7 +70,7 @@ data class TripRecord(
         tripType2 = elements[15],
         note = elements[16],
         note2 = elements[17],
-        direction = parseToInt(elements[18]),
+        direction = elements[18].trim().toIntOrNull(),
         vehicleType = parseToInt(elements[19]),
         isVehicleTypeMandatory = parseToBoolean(elements[20]),
         isBackupTrip = parseToBoolean(elements[21]),

--- a/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripStopRecord.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/data/hastus/TripStopRecord.kt
@@ -34,6 +34,11 @@ data class TripStopRecord(
     val note: String
 ) : HastusData() {
 
+    // The value of timing place is taken if the stop point is used as a timing point in journey
+    // pattern.
+    val effectiveTimingPlace: String?
+        get() = timingPlace?.takeIf { stopType == "T" || stopType == "R" }
+
     constructor(elements: List<String>) : this(
         tripInternalNumber = elements[1],
         timingPlace = elements[2].takeIf { it.isNotBlank() },

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastus.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastus.kt
@@ -67,10 +67,10 @@ object ConversionsFromHastus {
         val vehicleServices: List<JoreVehicleService> = vehicleServiceNames.map { vehicleServiceName ->
             mapToJoreVehicleService(
                 vehicleServiceName,
+                vehicleTypeIndex,
                 dayTypeId,
                 hastusBlockIndex.filter { block -> block.key.vehicleServiceName == vehicleServiceName },
-                journeyPatternRefIndex,
-                vehicleTypeIndex
+                journeyPatternRefIndex
             )
         }
 
@@ -127,10 +127,10 @@ object ConversionsFromHastus {
 
     private fun mapToJoreVehicleService(
         vehicleServiceName: String,
+        vehicleTypeIndex: Map<Int, UUID>,
         dayTypeId: UUID,
         hastusBlockIndex: Map<BlockRecord, Map<TripRecord, List<TripStopRecord>>>,
-        journeyPatternRefIndex: Map<RouteLabelAndDirection, JoreJourneyPatternRef>,
-        vehicleTypeIndex: Map<Int, UUID>
+        journeyPatternRefIndex: Map<RouteLabelAndDirection, JoreJourneyPatternRef>
     ): JoreVehicleService {
         return JoreVehicleService(
             vehicleServiceName,

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastus.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ConversionsFromHastus.kt
@@ -321,6 +321,7 @@ object ConversionsFromHastus {
         return when (trip.direction) {
             1 -> JoreRouteDirection.OUTBOUND
             2 -> JoreRouteDirection.INBOUND
+            null -> throw IllegalArgumentException("Null route direction encountered (dead run)")
             else -> throw IllegalArgumentException("Unknown Hastus route direction: ${trip.direction}")
         }
     }

--- a/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ImportService.kt
+++ b/src/main/kotlin/fi/hsl/jore4/hastus/service/importing/ImportService.kt
@@ -106,7 +106,11 @@ class ImportService(private val graphQLServiceFactory: GraphQLServiceFactory) {
                 // records for both arrival and departure time.
                 val hastusStopPointsAndTimingPlaces: List<Pair<String, String?>> =
                     filterOutConsecutiveDuplicates(
-                        hastusTripStops.map { it.stopId to it.timingPlace }
+                        hastusTripStops.map {
+                            // By using effectiveTimingPlace, it is taken into account whether the
+                            // stop point is used as a timing point in journey pattern.
+                            it.stopId to it.effectiveTimingPlace
+                        }
                     )
 
                 val hastusStopPointLabels: List<String> = hastusStopPointsAndTimingPlaces.map { it.first }


### PR DESCRIPTION
- Fix handling of timing place codes in import feature
- Fix encoding issues by setting `ISO-8859-1` encoding in appropriate places
- Filter out dead runs while importing timetables

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hastus/53)
<!-- Reviewable:end -->
